### PR TITLE
add option to specify cutoff year for eval

### DIFF
--- a/humun_benchmark/benchmark.py
+++ b/humun_benchmark/benchmark.py
@@ -29,6 +29,7 @@ def benchmark(
     batch_size: int = 10,
     train_ratio: int = 3,
     forecast_steps: int = 12,
+    cutoff_year: int = 2022,
     cuda: Optional[Union[int, str]] = "accelerate",
 ) -> None:
     """
@@ -60,6 +61,7 @@ def benchmark(
         "batch_size": batch_size,
         "train_ratio": train_ratio,
         "forecast_steps": forecast_steps,
+        "cutoff_year": cutoff_year,
         "cuda": cuda,
     }
     params_str = "\n".join(f"\t{k}: {v}" for k, v in params.items())
@@ -72,6 +74,7 @@ def benchmark(
         n_datasets=n_datasets,
         forecast_steps=forecast_steps,
         train_ratio=train_ratio,
+        cutoff_year=cutoff_year
     )
 
     # generate forecasts for each model
@@ -127,7 +130,6 @@ def benchmark(
 
 if __name__ == "__main__":
     models = [
-        "Qwen/Qwen2.5-1.5B-Instruct",
         "Qwen/Qwen2.5-3B-Instruct",
         "Qwen/Qwen2.5-7B-Instruct",
         "meta-llama/Llama-3.2-1B-Instruct",
@@ -141,6 +143,7 @@ if __name__ == "__main__":
         series_ids=MD_VINTAGE_IDS_MONTHLY,
         n_datasets=20,
         batch_size=10,
-        train_ratio=3,
-        forecast_steps=12,
+        train_ratio=7,
+        forecast_steps=6,
+        cutoff_year=2022,
     )

--- a/humun_benchmark/data/preprocessing.py
+++ b/humun_benchmark/data/preprocessing.py
@@ -47,6 +47,7 @@ def load_from_parquet(
     n_datasets: int = None,
     forecast_steps: int = 6,
     train_ratio: int = 3,
+    cutoff_year: int = None,
 ) -> Dict[str, Dict]:
     """
     Get timeseries data for specific series IDs, split into history and forecast.
@@ -57,6 +58,7 @@ def load_from_parquet(
         n_datasets: Limits the number of series to use.
         forecast_steps: Number of timesteps in forecast.
         train_ratio: Multiplier for training data (i.e. ratio of 3 * 6 = 18 training timesteps)
+        cutoff_year: If provided, only include data from this year onwards (e.g., 2024)
 
     Returns:
         Dictionary of format:
@@ -93,6 +95,24 @@ def load_from_parquet(
 
             timeseries_df["date"] = pd.to_datetime(timeseries_df["date"])
             timeseries_df["value"] = timeseries_df["value"].astype(float)
+            
+            # Apply year cutoff filter if specified
+            if cutoff_year is not None:
+                timeseries_df = timeseries_df[timeseries_df["date"].dt.year >= cutoff_year]
+                
+                # Check if we still have data after filtering
+                if len(timeseries_df) == 0:
+                    log.warning(f"Series {sid} has no data after applying year cutoff of {cutoff_year}. Skipping.")
+                    continue
+                    
+                # Check if we have enough data for truncation after filtering
+                total_required = (train_ratio + 1) * forecast_steps
+                if len(timeseries_df) < total_required:
+                    log.warning(
+                        f"Series {sid} has insufficient data after year cutoff ({len(timeseries_df)} rows, "
+                        f"need {total_required}). Skipping."
+                    )
+                    continue
 
             # truncate data
             history, forecast = truncate_dataset(timeseries_df, train_ratio, forecast_steps)
@@ -115,8 +135,17 @@ def dataset_info(series_id, title, original, history, forecast) -> str:
     o_len = len(original["value"])
     n_len = len(history["value"]) + len(forecast["value"])
     freq = pd.infer_freq(original["date"].sort_values()) or "Unknown"
+    
+    # Add date range info to make year filtering more transparent
+    date_range = f"{original['date'].min().strftime('%Y-%m-%d')} to {original['date'].max().strftime('%Y-%m-%d')}"
 
-    return f"ID: {series_id}\n Title: {title}\n Frequency: {freq}\n Values: {o_len} -> {n_len}"
+    return (
+        f"ID: {series_id}\n"
+        f"Title: {title}\n"
+        f"Frequency: {freq}\n"
+        f"Date Range: {date_range}\n"
+        f"Values: {o_len} -> {n_len}"
+    )
 
 
 if __name__ == "__main__":
@@ -130,7 +159,7 @@ if __name__ == "__main__":
     result = load_from_parquet(
         series_ids=MD_VINTAGE_IDS_MONTHLY,
         datasets_path="/workspace/datasets/fred/fred.parquet",
-        require_metadata="/workspace/datasets/fred/all_fred_metadata.csv",
+        cutoff_year=2022,
     )
 
     outputfile = "result.pkl"


### PR DESCRIPTION
This PR adds a cutoff year option to filter the data used for evaluation. 
* I confirmed that running `python humun_benchmark/data/preprocessing.py` returns a result in the proper format
* Currently the cutoff year needs to be set to 2022, otherwise there are not enough entries for the history and forecast window. I suppose in training, we can set the cutoff year to 2024 (basically, we just don't want the forecast window to be seen in training). Maybe we should implement it so that the cutoff year applies to the forecast window and we simply go as far back to fill the context window (i.e. `train_ratio * forecast_steps`)?